### PR TITLE
Refactor install script for conda support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore taxonomy dump and intermediate files
+taxdump/
+*.tar.gz
+*.dmp

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/bash
-
-pip3 install biopython
-pip3 install PyYAML
-wget "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz"
-tar xzf new_taxdump.tar.gz
-cat fullnamelineage.dmp|sed "s/\s\+\|\s\+//g"|sed 's/\|//2g'|awk 'BEGIN{FS="|"}{print $1,$3,$4,$2}'|sed "s/\s/\t/g"|sort -k1,1 > fullnamelineage_taxid_sorted.dmp

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ d-chimer produces all the outputs in the repository where it was launched.
 
 
 ## 3. Installation
-Users can execute the `INSTALL.sh` bash script once this repo is cloned, to get d-chimer source code, the python libraries and custom data.
+Users can execute the `install.sh` bash script once this repo is cloned, to get d-chimer source code, the python libraries and custom data.
+The script installs dependencies in the currently active Python environment (compatible with a conda env) and
+downloads the NCBI taxonomy dump into a dedicated `taxdump/` directory while cleaning up temporary files.
 ### 3.1 d-chimer code and python libraries : 
 - Clone or download the d-chimer repository.   
 
@@ -134,13 +136,13 @@ It is available at https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_tax
     
  - Decompress it using, for example: 
     
-       tar xzf new_taxdump.tar.gz
-       
+       tar xzf new_taxdump.tar.gz -C taxdump fullnamelineage.dmp
+
  - Create a tab delimited taxo file :
- 
- The command used here reformats the original NCBI `fullnamelineage.dmp` file into a `taxid sorted` tabulated file, named `fullnamelineage_taxid_sorted.dmp`.
- 
-        cat fullnamelineage.dmp|sed "s/\s\+\|\s\+//g"|sed 's/\|//2g'|awk 'BEGIN{FS="|"}{print $1,$3,$4,$2}'|sed "s/\s/\t/g"|sort -k1,1 > fullnamelineage_taxid_sorted.dmp
+
+ The command used here reformats the original NCBI `fullnamelineage.dmp` file into a `taxid sorted` tabulated file, named `fullnamelineage_taxid_sorted.dmp`, stored under `taxdump/`.
+
+        cat taxdump/fullnamelineage.dmp|sed "s/\s\+|\s\+//g"|sed 's/\|//2g'|awk 'BEGIN{FS="|"}{print $1,$3,$4,$2}'|sed "s/\s/\t/g"|sort -k1,1 > taxdump/fullnamelineage_taxid_sorted.dmp
 
 #### 3.2.2 custom viral database.
 Using the ncbi nr database directly were too long for BLASTx searche, we used a custom database for the BLASTx version. 
@@ -192,7 +194,7 @@ Once the zip file downloaded and decompressed, users must specify its path in th
           I : 1
 
         add_taxo_parameters :
-          tax_lineages_file : /home/user/db/fullnamelineage_taxid_sorted.dmp
+          tax_lineages_file : /path/to/taxdump/fullnamelineage_taxid_sorted.dmp
          
           blast_path : /home/user/tools/ncbi-blast-2.12.0+/bin
 

--- a/dchimer_config.yaml
+++ b/dchimer_config.yaml
@@ -21,6 +21,6 @@ filter_blastx_parameters :
   I : 1
 
 add_taxo_parameters :
-  tax_lineages_file : /home/path/to/fullnamelineage_taxid_sorted.dmp
+  tax_lineages_file : /path/to/taxdump/fullnamelineage_taxid_sorted.dmp
 
 blast_path : /path/to/ncbi-blast-2.12.0+/bin

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Python dependencies into the active environment
+python3 -m pip install --upgrade biopython PyYAML
+
+# Download and process the NCBI taxonomy dump
+TAXDUMP_DIR="taxdump"
+mkdir -p "$TAXDUMP_DIR"
+
+wget -q https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz \
+  -O "$TAXDUMP_DIR/new_taxdump.tar.gz"
+
+tar -xzf "$TAXDUMP_DIR/new_taxdump.tar.gz" -C "$TAXDUMP_DIR" fullnamelineage.dmp
+rm "$TAXDUMP_DIR/new_taxdump.tar.gz"
+
+sed -e 's/\s\+|\s\+//g' "$TAXDUMP_DIR/fullnamelineage.dmp" \
+  | sed 's/|//2g' \
+  | awk 'BEGIN{FS="|"}{print $1,$3,$4,$2}' \
+  | sed 's/\s/\t/g' \
+  | sort -k1,1 > "$TAXDUMP_DIR/fullnamelineage_taxid_sorted.dmp"
+
+rm "$TAXDUMP_DIR/fullnamelineage.dmp"


### PR DESCRIPTION
## Summary
- rewrite install script to respect active Python envs and clean taxonomy dump into dedicated folder
- document updated install process and config path
- ignore downloaded taxonomy dumps

## Testing
- `bash -n install.sh`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a199d7eba4832093e017f284e3b5f6