### PR TITLE
Handle missing env vars gracefully

### DIFF
--- a/dchimer_methods.py
+++ b/dchimer_methods.py
@@ -61,7 +61,12 @@ def _expand_and_check(path_value, name, parent=False, is_file=False, is_dir=Fals
     expanded = os.path.expandvars(path_value)
 
     if "$" in expanded:
-        missing = re.findall(r"\$([A-Za-z_][A-Za-z0-9_]*)", expanded)[0]
+        # Attempt to extract the missing variable name from either $VAR or ${VAR}
+        match = re.search(r"\$(?:{([A-Za-z_][A-Za-z0-9_]*)}|([A-Za-z_][A-Za-z0-9_]*))",
+                          path_value)
+        missing = ""
+        if match:
+            missing = match.group(1) or match.group(2)
         raise EnvironmentError(
             f"Environment variable '{missing}' required for '{name}' is not set"
         )


### PR DESCRIPTION
## Summary
- avoid IndexError in path expansion when config uses `${VAR}` notation
- report missing environment variables explicitly

## Testing
- `pip install pyyaml biopython` *(fails: Could not find a version that satisfies the requirement pyyaml)*
- `python3 dchimer.py -p blastn -L True -f testSequences.fasta` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a1c9a7b0d48320b82ad3feb353f560