### PR TITLE
Add pinned conda environment and update installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,49 +102,48 @@ For full view of d-chimer options, type :
 d-chimer produces all the outputs in the repository where it was launched.
 
 
-## 3. Installation
-Users can execute the `install.sh` bash script once this repo is cloned, to get d-chimer source code, the python libraries and custom data.
-The script installs dependencies in the currently active Python environment (compatible with a conda env) and
-downloads the NCBI taxonomy dump into a dedicated `taxdump/` directory while cleaning up temporary files.
-### 3.1 d-chimer code and python libraries : 
-- Clone or download the d-chimer repository.   
+## 3. Installation (recommended)
+The recommended and supported installation method is via conda, which provides a reproducible environment
+without modifying the system Python.
 
-             git clone https://github.com/stirera/d-chimer_v1
+### 3.1 Create the conda environment
+Clone or download the d-chimer repository, then run:
 
+```bash
+conda env create -f environment.yml
+conda activate dchimer
+```
 
-d-chimer depends on several python3 libraries and ncbi-BLAST and databases.
-- Python libraries
-  - Biopython and PyYAML
-
-   - For example, using python pip command as below:
-   
-
-            pip install biopython
-
-            pip install PyYAML
-
-### 3.2 **d-chimer custom data :**
-#### 3.2.1 taxonomic lineages :
+### 3.2 NCBI taxonomy data (manual)
 The taxonomic full lineage paths are needed for d-chimer to complete its run correctly ***** see also section 5.4 below fo details.*****
 It is available at https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz
 
-- Using unix wget command (for example) to download:  
+Download the taxonomy dump and place the processed file in `taxdump/`:
 
-      wget "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz"
+```bash
+mkdir -p taxdump
+wget "https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz"
+tar xzf new_taxdump.tar.gz -C taxdump fullnamelineage.dmp
+cat taxdump/fullnamelineage.dmp \
+  | sed "s/\\s\\+|\\s\\+//g" \
+  | sed 's/|//2g' \
+  | awk 'BEGIN{FS="|"}{print $1,$3,$4,$2}' \
+  | sed "s/\\s/\\t/g" \
+  | sort -k1,1 > taxdump/fullnamelineage_taxid_sorted.dmp
+```
       
- The file named "new_taxdump.tar.gz", takes few seconds to be downloaded.
-    
- - Decompress it using, for example: 
-    
-       tar xzf new_taxdump.tar.gz -C taxdump fullnamelineage.dmp
+Set `add_taxo_parameters.tax_lineages_file` in `d-chimer_config.yaml` to the path of
+`taxdump/fullnamelineage_taxid_sorted.dmp`.
 
- - Create a tab delimited taxo file :
+### 3.3 Legacy installation (deprecated)
+The `install.sh` script is deprecated. It installs dependencies into the active Python environment and
+downloads taxonomy data automatically. Use the conda-based installation above for reproducibility.
 
- The command used here reformats the original NCBI `fullnamelineage.dmp` file into a `taxid sorted` tabulated file, named `fullnamelineage_taxid_sorted.dmp`, stored under `taxdump/`.
+```bash
+bash install.sh
+```
 
-        cat taxdump/fullnamelineage.dmp|sed "s/\s\+|\s\+//g"|sed 's/\|//2g'|awk 'BEGIN{FS="|"}{print $1,$3,$4,$2}'|sed "s/\s/\t/g"|sort -k1,1 > taxdump/fullnamelineage_taxid_sorted.dmp
-
-#### 3.2.2 custom viral database.
+#### 3.4 custom viral database.
 Using the ncbi nr database directly were too long for BLASTx searche, we used a custom database for the BLASTx version. 
 It is made by downloading all proteing sequences in ncbi nr protein database.
 The produced fasta file was deduplicated using cd-hit (http://weizhong-lab.ucsd.edu/cd-hit/ or https://github.com/weizhongli/cdhit). 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+name: dchimer
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.10.13
+  - biopython=1.83
+  - pyyaml=6.0.1
+  - blast=2.14.1
+  - coreutils=9.4
+  - gawk=5.3.0
+  - sed=4.9
+  - wget=1.21.4

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# DEPRECATED: use conda environment.yml for reproducible installation
 set -euo pipefail
 
 # Install Python dependencies into the active environment


### PR DESCRIPTION
### Motivation
- Provide a clean, reproducible, conda-based installation that does not modify the system Python or rely on ad-hoc pip installs.
- Ensure installation is explicit and repeatable by pinning versions for required dependencies only.
- Keep the automatic taxonomy download as an explicit manual step to avoid hidden network actions during install.
- Deprecate the old install script while preserving it for legacy workflows.

### Description
- Add `environment.yml` with pinned versions and required packages (`python`, `biopython`, `pyyaml`, `blast`, `coreutils`, `gawk`, `sed`, `wget`) and channels (`conda-forge`, `bioconda`).
- Update `README.md` to include an “Installation (recommended)” section showing exact commands `conda env create -f environment.yml` and `conda activate dchimer` and a manual taxonomy download block that explains how to place `taxdump/fullnamelineage_taxid_sorted.dmp`.
- Move legacy instructions into a “Legacy installation (deprecated)” subsection and add an example `bash install.sh` invocation.
- Prepend a deprecation comment to `install.sh` (`# DEPRECATED: use conda environment.yml for reproducible installation`) without removing the script.

### Testing
- No automated tests were run for these documentation and environment-file changes.
- The change set is limited to `environment.yml`, `README.md`, and `install.sh` and does not alter runtime code or algorithms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f8017f7648320b66363cbed5efa6f)